### PR TITLE
Alphanumeric cnpj

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '8'
-          distribution: 'adoptium'
+          distribution: 'temurin'
 
 
       - name: cache maven deps

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,0 +1,36 @@
+name: Unit tests
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+
+      - name: setup jdk 8
+        uses: actions/setup-java@2
+        with:
+          java-version: '8'
+          distribution: 'adoptopenjdk'
+
+
+      - name: cache maven deps
+        uses: actions/cache@v2
+        with:
+            path: ~/.m2/repository   # Cache para dependências do Maven
+            key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}  # Chave para o cache
+            restore-keys: |
+              ${{ runner.os }}-maven-
+
+      - name: Build with Maven
+        run: mvn clean install -DskipTests=true  # A opção -DskipTests=true pode ser usada se você não quiser rodar os testes nesse passo
+
+      - name: Run tests with Maven
+        run: mvn test   # Executa os testes com Maven
+
+      - name: Build JAR with Spring Boot
+        run: mvn spring-boot:repackage

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: setup jdk 8
-        uses: actions/setup-java@2
+        uses: actions/setup-java@v2
         with:
           java-version: '8'
           distribution: 'adoptopenjdk'

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -17,20 +17,5 @@ jobs:
           java-version: '8'
           distribution: 'temurin'
 
-
-      - name: cache maven deps
-        uses: actions/cache@v2
-        with:
-            path: ~/.m2/repository   # Cache para dependências do Maven
-            key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}  # Chave para o cache
-            restore-keys: |
-              ${{ runner.os }}-maven-
-
-      - name: Build with Maven
-        run: mvn clean install -DskipTests=true  # A opção -DskipTests=true pode ser usada se você não quiser rodar os testes nesse passo
-
       - name: Run tests with Maven
         run: mvn test   # Executa os testes com Maven
-
-      - name: Build JAR with Spring Boot
-        run: mvn spring-boot:repackage

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '8'
-          distribution: 'adoptopenjdk'
+          distribution: 'adoptium'
 
 
       - name: cache maven deps

--- a/src/main/java/br/com/safeguard/proxies/CnpjProxy.java
+++ b/src/main/java/br/com/safeguard/proxies/CnpjProxy.java
@@ -1,0 +1,14 @@
+package br.com.safeguard.proxies;
+
+import br.com.safeguard.interfaces.BaseParam;
+import br.com.safeguard.types.ParametroTipo;
+
+public class CnpjProxy {
+    public static BaseParam apply(String value, BaseParam param) {
+        if(!value.matches("[0-9./-]+") && param.equals(ParametroTipo.CNPJ)){
+            return ParametroTipo.CNPJ_ALFANUMERICO;
+        }
+
+        return param;
+    }
+}

--- a/src/main/java/br/com/safeguard/types/ParametroTipo.java
+++ b/src/main/java/br/com/safeguard/types/ParametroTipo.java
@@ -34,6 +34,7 @@ import br.com.caelum.stella.validation.ie.IESergipeValidator;
 import br.com.caelum.stella.validation.ie.IETocantinsValidator;
 import br.com.safeguard.interfaces.BaseParam;
 import br.com.safeguard.patterns.Patterns;
+import br.com.safeguard.validators.CNPJAlphanumericValidator;
 import br.com.safeguard.validators.PatternValidator;
 
 /**
@@ -67,7 +68,7 @@ public enum ParametroTipo implements BaseParam{
 	CNPJ																	(new CNPJValidator()),
 	/**Cadeia de caracteres que representa um CNPJ formatado*/
 	CNPJ_FORMATADO															(new CNPJValidator(true)),
-	
+	CNPJ_ALFANUMERICO                                                       (new CNPJAlphanumericValidator()),
 	/**Cadeia de caracteres que representa uma Inscrição estadual*/
 	IE_ACRE_AC 	 															(new IEAcreValidator()),
 	/**Cadeia de caracteres que representa uma Inscrição estadual*/

--- a/src/main/java/br/com/safeguard/validators/CNPJAlphanumericValidator.java
+++ b/src/main/java/br/com/safeguard/validators/CNPJAlphanumericValidator.java
@@ -1,0 +1,94 @@
+package br.com.safeguard.validators;
+
+import br.com.caelum.stella.MessageProducer;
+import br.com.caelum.stella.SimpleMessageProducer;
+import br.com.caelum.stella.ValidationMessage;
+import br.com.caelum.stella.validation.InvalidStateException;
+import br.com.caelum.stella.validation.Validator;
+import br.com.caelum.stella.validation.error.CNPJError;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CNPJAlphanumericValidator implements Validator<String>  {
+    private static final int[] MULTIPLICADOR1 = {5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2};
+    private static final int[] MULTIPLICADOR2 = {6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2};
+
+    private final MessageProducer messageProducer;
+
+    public CNPJAlphanumericValidator(){
+        this.messageProducer = new SimpleMessageProducer();
+    }
+
+    @Override
+    public void assertValid(String s) {
+        List<ValidationMessage> errors = this.getInvalidValues(s);
+        if (!errors.isEmpty()) {
+            throw new InvalidStateException(errors);
+        }
+    }
+
+    private List<ValidationMessage> getInvalidValues(String cnpj) {
+        List<ValidationMessage> errors = new ArrayList<>();
+
+        if (cnpj != null) {
+
+            String cnpjSemDigito = cnpj.substring(0, cnpj.length() - 2);
+            String digitos = cnpj.substring(cnpj.length() - 2);
+            String digitosCalculados = calcularDigitosVerificadores(cnpjSemDigito);
+
+            if (!digitos.equals(digitosCalculados)) {
+                errors.add(this.messageProducer.getMessage(CNPJError.INVALID_CHECK_DIGITS));
+            }
+
+        }
+        return errors;
+    }
+
+    public static String calcularDigitosVerificadores(String cnpj) {
+        cnpj = cnpj.replaceAll("[^0-9A-Za-z]", "");
+        int[] valores = converterParaNumeros(cnpj);
+
+        int primeiroDV = calcularDigito(valores, MULTIPLICADOR1);
+        int[] valoresComDV1 = new int[valores.length + 1];
+        System.arraycopy(valores, 0, valoresComDV1, 0, valores.length);
+        valoresComDV1[valores.length] = primeiroDV;
+        int segundoDV = calcularDigito(valoresComDV1, MULTIPLICADOR2);
+
+        return String.valueOf(primeiroDV) + segundoDV;
+    }
+
+    private static int[] converterParaNumeros(String cnpj) {
+        int[] valores = new int[cnpj.length()];
+        for (int i = 0; i < cnpj.length(); i++) {
+            char c = cnpj.charAt(i);
+            if (Character.isDigit(c)) {
+                valores[i] = c - '0';
+            } else {
+                valores[i] = (int) c - 48; // Conversão ASCII, subtraindo 48
+            }
+        }
+        return valores;
+    }
+
+    private static int calcularDigito(int[] valores, int[] multiplicadores) {
+        int soma = 0;
+        int tamanho = multiplicadores.length;
+        int inicio = valores.length - tamanho;
+        for (int i = 0; i < tamanho; i++) {
+            soma += valores[inicio + i] * multiplicadores[i];
+        }
+        int resto = soma % 11;
+        return (resto < 2) ? 0 : 11 - resto;
+    }
+
+    @Override
+    public List<ValidationMessage> invalidMessagesFor(String s) {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public boolean isEligible(String s) {
+        return true;
+    }
+}

--- a/src/main/java/br/com/safeguard/verifies/ParamVerify.java
+++ b/src/main/java/br/com/safeguard/verifies/ParamVerify.java
@@ -10,6 +10,7 @@ import br.com.safeguard.constraint.annotations.Verify;
 import br.com.safeguard.exceptions.SafeguardException;
 import br.com.safeguard.interfaces.BaseParam;
 import br.com.safeguard.params.Param;
+import br.com.safeguard.proxies.CnpjProxy;
 
 /**  
  *  Classe de verificação genérica para uma cadeia de caracteres formatados ou não, os dados podem ser
@@ -55,7 +56,11 @@ public class ParamVerify {
 		if(elements.isEmpty()) {
 			throw new SafeguardException("The map can not be empty");
 		}
-		elements.forEach((Integer, param) -> assertValid(param.getValue(), param.getType()));
+
+
+		elements.forEach((Integer, param) -> {
+			BaseParam proxyParam = CnpjProxy.apply(param.getValue(), param.getType());
+			assertValid(param.getValue(), proxyParam);});
 	}
 	
 	/**

--- a/src/test/java/com/gilmarcarlos/developer/safeguard/Annotation/CnpjAnnotationTest.java
+++ b/src/test/java/com/gilmarcarlos/developer/safeguard/Annotation/CnpjAnnotationTest.java
@@ -1,29 +1,17 @@
-package com.gilmarcarlos.developer.safeguard;
+package com.gilmarcarlos.developer.safeguard.Annotation;
 
 import br.com.safeguard.check.SafeguardCheck;
 import br.com.safeguard.constraint.annotations.Verify;
+import br.com.safeguard.interfaces.Check;
 import br.com.safeguard.types.ParametroTipo;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.Serializable;
 
-public class CnpjTest {
-
+public class CnpjAnnotationTest {
     @Test
-    public void cnpjLegacy() {
-        SafeguardCheck checker = new SafeguardCheck();
-
-        String cnpjLegacy = "00.623.904/0001-73";
-
-        boolean isValid = !checker.elementOf(cnpjLegacy, ParametroTipo.CNPJ).validate().hasError();
-
-        System.out.println(isValid);
-        Assert.assertTrue(isValid);
-    }
-
-    @Test
-    public void cnpjAnnotation() {
+    public void ShouldBeValidCNPJ() {
         SafeguardCheck checker = new SafeguardCheck();
 
         String cnpjLegacy = "00.623.904/0001-73";
@@ -31,11 +19,28 @@ public class CnpjTest {
         Company company = new Company();
         company.setCnpj(cnpjLegacy);
 
-        boolean isValid = !checker.elementOf(company.getCnpj(), ParametroTipo.CNPJ).validate().hasError();
+        Check results = checker.elementOf(company).validate();
 
-        System.out.println(isValid);
+        boolean isValid = !results.hasError();
+
         Assert.assertTrue(isValid);
     }
+
+//    @Test
+//    public void ShouldBeValidAlphaCNPJ() {
+//        SafeguardCheck checker = new SafeguardCheck();
+//
+//        String cnpjLegacy = "ab.623.904/0001-73";
+//
+//        Company company = new Company();
+//        company.setCnpj(cnpjLegacy);
+//
+//        Check results = checker.elementOf(company).validate();
+//
+//        boolean isValid = !results.hasError();
+//
+//        Assert.assertTrue(isValid);
+//    }
 
     static class Company implements Serializable {
         @Verify(value = ParametroTipo.CNPJ)

--- a/src/test/java/com/gilmarcarlos/developer/safeguard/CnpjTest.java
+++ b/src/test/java/com/gilmarcarlos/developer/safeguard/CnpjTest.java
@@ -1,0 +1,52 @@
+package com.gilmarcarlos.developer.safeguard;
+
+import br.com.safeguard.check.SafeguardCheck;
+import br.com.safeguard.constraint.annotations.Verify;
+import br.com.safeguard.types.ParametroTipo;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.Serializable;
+
+public class CnpjTest {
+
+    @Test
+    public void cnpjLegacy() {
+        SafeguardCheck checker = new SafeguardCheck();
+
+        String cnpjLegacy = "00.623.904/0001-73";
+
+        boolean isValid = !checker.elementOf(cnpjLegacy, ParametroTipo.CNPJ).validate().hasError();
+
+        System.out.println(isValid);
+        Assert.assertTrue(isValid);
+    }
+
+    @Test
+    public void cnpjAnnotation() {
+        SafeguardCheck checker = new SafeguardCheck();
+
+        String cnpjLegacy = "00.623.904/0001-73";
+
+        Company company = new Company();
+        company.setCnpj(cnpjLegacy);
+
+        boolean isValid = !checker.elementOf(company.getCnpj(), ParametroTipo.CNPJ).validate().hasError();
+
+        System.out.println(isValid);
+        Assert.assertTrue(isValid);
+    }
+
+    static class Company implements Serializable {
+        @Verify(value = ParametroTipo.CNPJ)
+        private String cnpj;
+
+        public String getCnpj() {
+            return cnpj;
+        }
+
+        public void setCnpj(String cnpj){
+            this.cnpj = cnpj;
+        }
+    }
+}

--- a/src/test/java/com/gilmarcarlos/developer/safeguard/Parameter/CnpjParameterTest.java
+++ b/src/test/java/com/gilmarcarlos/developer/safeguard/Parameter/CnpjParameterTest.java
@@ -1,0 +1,22 @@
+package com.gilmarcarlos.developer.safeguard.Parameter;
+
+import br.com.safeguard.check.SafeguardCheck;
+import br.com.safeguard.types.ParametroTipo;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CnpjParameterTest {
+
+    @Test
+    public void ShouldBeValidCnpj() {
+        SafeguardCheck checker = new SafeguardCheck();
+
+        String cnpjLegacy = "00.623.904/0001-73";
+
+        boolean isValid = !checker.elementOf(cnpjLegacy, ParametroTipo.CNPJ).validate().hasError();
+
+        System.out.println(isValid);
+        Assert.assertTrue(isValid);
+    }
+
+}

--- a/src/test/java/com/gilmarcarlos/developer/safeguard/Parameter/CnpjParameterTest.java
+++ b/src/test/java/com/gilmarcarlos/developer/safeguard/Parameter/CnpjParameterTest.java
@@ -19,4 +19,26 @@ public class CnpjParameterTest {
         Assert.assertTrue(isValid);
     }
 
+    @Test
+    public void ShouldBeValidAlphaNumericCnpj(){
+        SafeguardCheck checker = new SafeguardCheck();
+
+        String cnpj = "12.ABC.345/01DE-35";
+
+        boolean isValid = !checker.elementOf(cnpj, ParametroTipo.CNPJ).validate().hasError();
+
+        Assert.assertTrue(isValid);
+    }
+
+    @Test
+    public void ShouldBInvalidAlphaNumericCnpj(){
+        SafeguardCheck checker = new SafeguardCheck();
+
+        String cnpj = "12.ABC.345/01DE-99";
+
+        boolean inValid = checker.elementOf(cnpj, ParametroTipo.CNPJ).validate().hasError();
+
+        Assert.assertTrue(inValid);
+    }
+
 }


### PR DESCRIPTION
# Summary 📚

- Added a CI/CD workflow for unit tests.
- Implemented new tests for both legacy CNPJ and alphanumeric CNPJ.
- Introduced a new validation for alphanumeric CNPJ.

# How to test 👨‍🔬⚗️🔬

## Legacy

```JAVA
String cnpj= "00.623.904/0001-73";

Check check = new SafeguardCheck();

boolean isValid = !checker.elementOf(cnpjLegacy, ParametroTipo.CNPJ).validate().hasError();
```
## Alphanumeric 

```JAVA
SafeguardCheck checker = new SafeguardCheck();

String cnpj = "12.ABC.345/01DE-35";

boolean isValid = !checker.elementOf(cnpj, ParametroTipo.CNPJ).validate().hasError();
```

# CI/CD Results 🚀

The unit test results can be found in the GitHub Actions workflow:
[View Test Results](https://github.com/Aleff13/java-validator-safeguard/actions/runs/13377915570)